### PR TITLE
Fixing php 7.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
 install:
   - composer install
 script: vendor/bin/phpunit --bootstrap=vendor/autoload.php

--- a/src/CM/Messaging/Response/Response.php
+++ b/src/CM/Messaging/Response/Response.php
@@ -30,14 +30,14 @@ class Response
      *
      * @var array
      */
-    private $accepted;
+    private $accepted = [];
 
     /**
      * Messaging(s) rejected by te server
      *
      * @var array
      */
-    private $failed;
+    private $failed = [];
 
     /**
      * Response constructor.

--- a/tests/CM/Messaging/ClientTest.php
+++ b/tests/CM/Messaging/ClientTest.php
@@ -64,7 +64,7 @@ class ClientTest extends TestCase
 
         $this->assertInstanceOf('\CM\Messaging\Response\Response', $result);
         $this->assertCount(1, $result->getAccepted());
-        $this->assertNull($result->getFailed());
+        $this->assertCount(0, $result->getFailed());
     }
 
     public function testSendBuildRequest()

--- a/tests/CM/Messaging/Response/ResponseTest.php
+++ b/tests/CM/Messaging/Response/ResponseTest.php
@@ -31,7 +31,7 @@ class ResponseTest extends TestCase
         $this->assertTrue($result->isAccepted());
         $this->assertCount(1, $result->getAccepted());
 
-        $this->assertNull($result->getFailed());
+        $this->assertCount(0, $result->getFailed());
     }
 
     public function testAllAcceptedMultiple()
@@ -45,7 +45,7 @@ class ResponseTest extends TestCase
         $this->assertTrue($result->isAccepted());
         $this->assertCount(3, $result->getAccepted());
 
-        $this->assertNull($result->getFailed());
+        $this->assertCount(0, $result->getFailed());
     }
 
     public function testAllSomeAcceptedMultiple()


### PR DESCRIPTION
When implementing this library I ran into a few using due to the changes of the count function in php 7.2.
http://php.net/manual/en/migration72.incompatible.php

This pull request fixes those issues and also enables testing of 7.2 in Travis CI.