### PR TITLE
Define accepted and failed properties as empty array

### DIFF
--- a/src/CM/Messaging/Response/Response.php
+++ b/src/CM/Messaging/Response/Response.php
@@ -30,14 +30,14 @@ class Response
      *
      * @var array
      */
-    private $accepted;
+    private $accepted = array();
 
     /**
      * Messaging(s) rejected by te server
      *
      * @var array
      */
-    private $failed;
+    private $failed = array();
 
     /**
      * Response constructor.


### PR DESCRIPTION
While using the count method on property failed, the value must implements Countable.
The method isAccepted uses the count method on $this->failed but without be sure this is an array.

Newer php versions might throw an exception.

EDIT:

this issue is already been fixed here: https://github.com/CMTelecom/messaging-php/pull/7
You can close this PR and merge the PR opened by Rojtjo last week.